### PR TITLE
add Docker support - fix #17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.7-alpine
+
+COPY . /app
+WORKDIR /app
+RUN pip install -r requirements.txt
+CMD ["python3", "./server.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '2.1'
+
+services:
+  miniprint:
+    image: miniprint
+    hostname: miniprint
+    build:
+      context: .
+    ports:
+      - "9100:9100"


### PR DESCRIPTION
fix #17 and add Docker support, uses a minimal Alpine image. docker-compose is used to easily expose port 9100. 